### PR TITLE
Added support for paging

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+[1.1.4] 2015-08-13 EV <evi@vzaar.com>
+
+  * added support for paging
+
 [1.1.3] 2015-07-29 JC <evi@vzaar.com>
 
   * custom curlExec() added for php setups with open_basedir or safe_mode enabled

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 { "name": "vzaar",
   "description": "The PHP client for Vzaar API.",
   "type": "library",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "keywords": [ "vzaar", "video", "api" ],
 
   "homepage": "https://github.com/vzaar/vzaar-api-php",

--- a/src/Vzaar.php
+++ b/src/Vzaar.php
@@ -132,7 +132,7 @@ class Vzaar
      * @param string $status
      * @return VideoList
      */
-    public static function getVideoList($username, $auth = false, $count = 20, $page = 1, $labels = '', $status = '')
+    public static function getVideoList($username, $auth = false, $count = 20, $labels = '', $status = '', $page = 1)
     {
         $_url = self::$url . 'api/' . $username . '/videos.json?count=' . $count;
         if ($labels != '') $_url .= "&labels=" . $labels;
@@ -384,7 +384,7 @@ class Vzaar
 
         return $video_id;
     }
-    
+
 
 
     /**
@@ -617,7 +617,7 @@ class Vzaar
 
     private static function _sanitize_str($str) {
         return strtr(
-            $str, 
+            $str,
             array(
                 "<" => "&lt;",
                 ">" => "&gt;",

--- a/src/Vzaar.php
+++ b/src/Vzaar.php
@@ -132,12 +132,14 @@ class Vzaar
      * @param string $status
      * @return VideoList
      */
-    public static function getVideoList($username, $auth = false, $count = 20, $labels = '', $status = '')
+    public static function getVideoList($username, $auth = false, $count = 20, $page = 1, $labels = '', $status = '')
     {
         $_url = self::$url . 'api/' . $username . '/videos.json?count=' . $count;
         if ($labels != '') $_url .= "&labels=" . $labels;
 
         if ($status != '') $_url .= '&status=' . $status;
+
+        if ($page) $_url .= '&page=' . $page;
 
         $req = new HttpRequest($_url);
         $req->verbose = Vzaar::$enableHttpVerbose;


### PR DESCRIPTION
#### Summary
Regarding `getVideoList()`: [https://github.com/vzaar/vzaar-api-php/blob/master/src/Vzaar.php#L135](https://github.com/vzaar/vzaar-api-php/blob/master/src/Vzaar.php#L135)

The [docs](http://developer.vzaar.com/docs/version_1.0/public/video_list.html) talk about a `page` parameter for retrieving large lists page by page. However, the current version of the lib doesn’t support it. 

#### Intended effect
This change introduces support for paging.

#### How I tested
Green specs.

#### Comments
This change was originally done by @skitsanos in this pull request: https://github.com/vzaar/vzaar-api-php/pull/6.

The git log had been rebased so I fixed that and reordered the method arguments to preserve backward compatibility.