### PR TITLE
(DVOP-61) Add basic support for Upload API 1.1 (chunked upload)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+[1.2.0] 2015-10-19 AO <alan@vzaar.com>
+
+  * added support for vzaar upload API 1.1
+  * adds support for chunked uploads
+  * adds upload_hostname to signature response
+
 [1.1.5] 2015-08-13 EJ <ed@vzaar.com>
 
   * updated composer.json for Packagist

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 { "name": "vzaar/vzaar-api-php",
   "description": "The PHP client for Vzaar API.",
   "type": "library",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "keywords": [ "vzaar", "video", "api" ],
 
   "homepage": "https://github.com/vzaar/vzaar-api-php",

--- a/examples/UploadVideoTest.php
+++ b/examples/UploadVideoTest.php
@@ -8,12 +8,12 @@ class UploadVideoTest extends PHPUnit_Framework_TestCase {
         Vzaar::$token = API_ENVS::get()["user1"]["rw_token"];
         Vzaar::$secret = API_ENVS::get()["user1"]["login"];
     }
-    
-    
+
+
     public function testUploadVideo() {
         $title = "api-php-" . generateRandomStr(5);
         $guid = Vzaar::uploadVideo(self::$filePath);
-        
+
         $videoId = Vzaar::processVideo($guid, $title, "php test", "");
 
         $vid = Vzaar::getVideoDetails($videoId, true);
@@ -21,6 +21,24 @@ class UploadVideoTest extends PHPUnit_Framework_TestCase {
 
         // clean up
         Vzaar::deleteVideo($videoId);
+    }
+
+    public function testNonMulitpartVideoSignature() {
+        $signature = Vzaar::getUploadSignature();
+        $policy = base64_decode($signature['vzaar-api']['policy']);
+
+        // doesn't have chunk and chunks policy
+        $this->assertNotContains('["starts-with","$chunk",""]', $policy);
+        $this->assertNotContains('["starts-with","$chunks",""]', $policy);
+    }
+
+    public function testMulitpartVideoSignature() {
+        $signature = Vzaar::getUploadSignature(null, true);
+        $policy = base64_decode($signature['vzaar-api']['policy']);
+
+        // has chunk and chunks policy
+        $this->assertContains('["starts-with","$chunk",""]', $policy);
+        $this->assertContains('["starts-with","$chunks",""]', $policy);
     }
 }
 ?>

--- a/src/UploadSignature.php
+++ b/src/UploadSignature.php
@@ -31,24 +31,24 @@ class UploadSignature {
      *
      * @param guid the vzaar global unique identifier
      * @param key a name for the S3 object that will store the uploaded
-     * 		file's data
+     *		file's data
      * @param https
      * @param acl the access control policy to apply to the uploaded file
      * @param bucket the vzaar bucket that has been allocated for this file
      * @param policy a Base64-encoded policy document that applies rules to
-     * 	file uploads sent by the S3 POST form. This document is used to authorise
-     * 	the form, and to impose conditions on the files that can be uploaded.
+     *	file uploads sent by the S2 POST form. This document is used to authorise
+     *	the form, and to impose conditions on the files that can be uploaded.
      * @param expirationDate s Greenwich Mean Time (GMT) timestamp that
-     * 	specifies when the policy document will expire. Once a policy document
-     * 	has expired, the upload will fail
+     *	specifies when the policy document will expire. Once a policy document
+     *	has expired, the upload will fail
      * @param accessKey the vzaar AWS Access Key Identifier credential
      * @param signature a signature value that authorises the form and proves
-     * 	that only vzaar could have created it. This value is calculated by signing
-     * 	the policy document
+     *	that only vzaar could have created it. This value is calculated by signing
+     *	the policy document
      */
     function __construct($guid, $key, $https, $acl,
             $bucket, $policy, $expirationDate,
-            $accessKeyId, $signature) {
+            $accessKeyId, $signature, $uploadHostname) {
         $this->guid = $guid;
         $this->key = $key;
         $this->https = $https;
@@ -58,6 +58,7 @@ class UploadSignature {
         $this->expirationdate = $expirationDate;
         $this->accesskeyid = $accessKeyId;
         $this->signature = $signature;
+        $this->uploadHostname = $uploadHostname;
     }
 
     static function fromJson($data) {

--- a/src/UploadSignature.php
+++ b/src/UploadSignature.php
@@ -36,7 +36,7 @@ class UploadSignature {
      * @param acl the access control policy to apply to the uploaded file
      * @param bucket the vzaar bucket that has been allocated for this file
      * @param policy a Base64-encoded policy document that applies rules to
-     *	file uploads sent by the S2 POST form. This document is used to authorise
+     *	file uploads sent by the S3 POST form. This document is used to authorise
      *	the form, and to impose conditions on the files that can be uploaded.
      * @param expirationDate s Greenwich Mean Time (GMT) timestamp that
      *	specifies when the policy document will expire. Once a policy document


### PR DESCRIPTION
#### Summary
This pull request adds support for the vzaar Upload API v1.1 to the PHP client library.

This will allow you to do chunked browser-based uploading, by specifying the 'chunks' parameter when completing an upload, referring to the number of pieces an upload has been split into.

#### Intended effect

`getUploadSignature` and `getUploadSignatureAsXml` will return the new v1.1 signature response, which will involve

1. Uploading to a new bucket
2. An optional `upload_hostname` indicating a CDN-backed endpoint for you to upload your video to, potentially boosting upload speeds, depending on your connection and your geographical location.

`processVideo` and `processVideoCustomized` calls will accept an optional chunks parameter. If your video has been split into a number of chunks. The file will be reassembled by vzaar before processing.

#### How I tested

The vzaar reference uploader was built to test this functionality: https://github.com/vzaar/chunked-browser-upload-reference-implementation

Please use this to test the new functionality provided by the client library.

This tests all new functionality end-to-end. In addition, new end-to-end specs have been added to test key aspects of the new functionality.
