### PR TITLE
couple of minor edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ echo($apireply)
 
 You would need to pass following parameters to this API function:
 
-* _GUID_ (string) - Specifies the guid to operate on. This should have been returned from the upload operation.
-* _VIDEO_TITLE_ (string) - Specifies the title for the video
+* _GUID_ (string) - Specifies the guid to operate on. This will have been the return value from the previous `uploadVideo` or `uploadLink` operation.
+* _VIDEO__TITLE_ (string) - Specifies the title for the video
 * _VIDEO_DESCRIPTION_ (string) - Specifies the description for the video
 * _PROFILE_ (integer) - Specifies the size for the video to be encoded in. If not specified, this will use the vzaar default or the user default (if set)
 * _VIDEO_LABELS_ (string) - Comma separated list of labels to be assigned to the video

--- a/README.md
+++ b/README.md
@@ -19,70 +19,65 @@ Vzaar::$token = 'VZAAR_API_TOKEN';
 Vzaar::$secret = 'VZAAR_USERNAME';
 ```
 
-In order to use vzaar API, you need to have a valid user name and API token that you can get from your vzaar dashboard at [http://app.vzaar.com/settings/api](http://app.vzaar.com/settings/api)
+In order to use the vzaar API, you need to have a valid username and API token that you can get from your vzaar dashboard at [http://app.vzaar.com/settings/api](http://app.vzaar.com/settings/api)
 
-The very next thing you would want to do is to check if your account actually works and operational and you can do it by simple calling _whoAmI_:
+To check you can connect via the API, you can run the following command:
 
 ```php
 echo(Vzaar::whoAmI());
 ```
 
-If it returns you your vzaar username, - we are good to go.
+If it returns you your vzaar username, then you're good to go.
 
 ####User Details
 
->This API call returns the user's public details along with it's relevant metadata. It also contains vzaar Account ID that you can use in _getAccountDetails_ call.
+This API call returns the user's public details along with relevant metadata.
 
 ```php
 print_r(Vzaar::getUserDetails('VZAAR_USERNAME'));
 ```
 
-Where _VZAAR_USERNAME_ is the vzaar username. Result of this call will be an object of UserDetails type.
+Where _VZAAR__USERNAME_ is the vzaar username. Result of this call will be an object of UserDetails type.
 
-####Account Details
-
->This API call returns the details and rights for each vzaar subscription account type along with it's relevant metadata. This will show the details of the packages available here: [http://vzaar.com/pricing](http://vzaar.com/pricing)
-
-```php
-print_r(Vzaar::getAccountDetails(VZAAR_ACCOUNT_ID));
-```
-
-Where _VZAAR_ACCOUNT_ID_ is the unique account id assigned by vzaar.
-
-Result of this call will be an object of AccountDetails type.
 
 ####Video List
 
->This API call returns a list of the user's active videos along with it's relevant metadata. 20 videos are returned by default, but this is customizable.
+This API call returns a list of the user's active videos along with relevant metadata. 20 videos are returned by default, but this is customizable.
 
 ```php
 print_r(Vzaar::getVideoList('VZAAR_USERNAME', true, 10));
 ```
 
+In this example, the `true` parameter says that the API call should be authenticated. If you have your API settings set to 'private', then you will need to be authenticated.
+
 ####Video Details
 
->This API call returns metadata about selected video, like its dimensions, thumbnail information, author, duration, play count and so on.
+This API call returns metadata about the selected video, like its dimensions, thumbnail information, author, duration, play count and so on.
 
 ```php
 print_r(Vzaar::getVideoDetails(VZAAR_VIDEO_ID, true));
 ```
 
-Where _VZAAR_VIDEO_ID_ is unique vzaar video ID assigned to a video after its processing.
+In this case, VZAAR_VIDEO_ID_ is the unique vzaar video ID assigned to a video after its processing.
 
 ####Upload Signature
 
->In some cases you might need to not perform actual uploading from API but to use some third-party uploaders, like S3_Upload widget, or any other, so you would need to get only upload signature for it.
+In some cases you might need to not perform actual uploading from API but to use some third-party uploaders, like S3_Upload widget or similar, so you would need to get only upload signature for it.
 
 ```php
 print_r(Vzaar::getUploadSignature());
 ```
 
-####Uploading video
+###Uploading and processing videos
 
->Upload video from local drive directly to Amazon S3 bucket. Use this method when you build desktop apps or when you upload videos to vzaar directly from your server.
+Getting a video into your vzaar account is a two step process; you must first upload and then process the video.
+
+####Uploading videos from the filesystem
+
+Upload video from local drive directly to Amazon S3 bucket. Use this method when you build desktop apps or when you upload videos to vzaar directly from your server.
 
 ```php
-$filename = '548.mov'; // the file must be located in the same directory as the script. If not use full disk path
+$filename = '548.mov'; // the file must be located in the same directory as the script. If not use full disk path.
 
 $file = getcwd() . '\\' . $filename;
 echo('file to upload: ' . $file);
@@ -90,9 +85,38 @@ $result=Vzaar::uploadVideo($file);
 echo($result);
 ```
 
+####Uploading videos using a url
+
+Uploading a new video or replacing an existing one from a url
+
+```php
+$url = "http://www.mywebsite.com/my_video.mp4";
+echo('uploading video from url: ' . $url);
+$video_id=Vzaar::uploadLink($url);
+echo($video_id);
+```
+
+####Processing videos
+
+This API call tells the vzaar system to process a newly uploaded video. This will encode it if necessary and then provide a vzaar video ID back.
+
+```php
+$apireply = Vzaar::processVideo(GUID, VIDEO_TITLE, VIDEO_DESCRIPTION, VIDEO_LABELS, Profile::Original);
+echo($apireply)
+```
+
+You would need to pass following parameters to this API function:
+
+* _GUID_ (string) - Specifies the guid to operate on. This should have been returned from the upload operation.
+* _VIDEO_TITLE_ (string) - Specifies the title for the video
+* _VIDEO_DESCRIPTION_ (string) - Specifies the description for the video
+* _PROFILE_ (integer) - Specifies the size for the video to be encoded in. If not specified, this will use the vzaar default or the user default (if set)
+* _VIDEO_LABELS_ (string) - Comma separated list of labels to be assigned to the video
+
+
 ####Uploading thumbnails
 
->Upload thumbnails for a video by using the video id.
+Upload thumbnails for a video by using the video id.
 
 ```php
 $video_id = 123;
@@ -105,7 +129,7 @@ echo($result);
 
 ####Uploading thumbnails
 
->Generate thumbnail based on frame time.
+Generate a thumbnail based on frame time.
 
 ```php
 $video_id = 123;
@@ -114,37 +138,10 @@ $result=Vzaar::generateThumbnail($video_id, 3);
 echo($result);
 ```
 
-####Uploading videos using urls
-
->Uploading a new video or replacing an existing one from an url
-
-```php
-$url = "http://www.mywebsite.com/my_video.mp4";
-echo('uploading video from url: ' . $url);
-$video_id=Vzaar::uploadLink($url);
-echo($video_id);
-```
-
-####Processing video
-
->This API call tells the vzaar system to process a newly uploaded video. This will encode it if necessary and then provide a vzaar video ID back.
-
-```php
-$apireply = Vzaar::processVideo(GUID, VIDEO_TITLE, VIDEO_DESCRIPTION, VIDEO_LABELS, Profile::Original);
-echo($apireply)
-```
-
-You would need to pass following parameters to this API function:
-
-* _GUID_ (string) - Specifies the guid to operate on
-* _VIDEO_TITLE_ (string) - Specifies the title for the video
-* _VIDEO_DESCRIPTION_ (string) - Specifies the description for the video
-* _PROFILE_ (integer) - Specifies the size for the video to be encoded in. If not specified, this will use the vzaar default or the user default (if set)
-* _VIDEO_LABELS_ (string) - Comma separated list of labels to be assigned to the video
 
 ####Editing video
 
->This API call allows a user to edit or change details about a video in the system.
+This API call allows a user to edit or change details about a video in the system.
 
 ```php
 $apiresult = Vzaar::editVideo(VIDEO_ID, VIDEO_TITLE, VIDEO_DESCRIPTION, MARK_AS_PRIVATE);
@@ -157,14 +154,13 @@ The following arguments should be passed to the method:
 * _VIDEO_DESCRIPTION_ (string) - Specifies the new description for the video
 * _MARK_AS_PRIVATE_ (boolean) (true|false) - Marks the video as private or public
 
+
 ####Deleting video
->This API call allows you to delete a video from your account. If deletion was successful it will return you _true_ otherwise _false_.
+This API call allows you to delete a video from your account. If deletion was successful it will return you _true_ otherwise _false_.
 
 ```php
 $apiresult = Vzaar::deleteVideo(VZAAR_VIDEO_ID);
 ```
-
-Where VZAAR_VIDEO_ID is unique vzaar video ID assigned to a video after its processing.
 
 
 ### License

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 { "name": "vzaar/vzaar-api-php",
   "description": "The PHP client for Vzaar API.",
   "type": "library",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "keywords": [ "vzaar", "video", "api" ],
 
   "homepage": "https://github.com/vzaar/vzaar-api-php",

--- a/src/Video.php
+++ b/src/Video.php
@@ -42,7 +42,7 @@ class Video
 		$video->thumbnail = $jo->thumbnail;
 		$video->width = $jo->width;
 		$video->height = $jo->height;
-		$video->framegrabUrl = 'http://vzaar.com/videos/' . $jo->id . '.frame';
+		$video->framegrabUrl = $jo->framegrab_url;
 
 		return $video;
 	}

--- a/src/VideoList.php
+++ b/src/VideoList.php
@@ -1,13 +1,7 @@
 <?php
-/* 
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
-*/
-
 /**
  * VideoList
  *
- * @author Skitsanos
  */
 require_once 'Video.php';
 require_once 'User.php';
@@ -30,7 +24,7 @@ class VideoList {
                 $video->duration = $jo[$i]->duration;
                 $video->playCount = $jo[$i]->play_count;
                 $video->title = $jo[$i]->title;
-		$video->description = $jo[$i]->description;
+                $video->description = $jo[$i]->description;
                 $video->url = $jo[$i]->url;
                 $video->createdAt = $jo[$i]->created_at;
                 $video->version = $jo[$i]->version;
@@ -43,7 +37,7 @@ class VideoList {
                 $video->thumbnail = $jo[$i]->thumbnail;
                 $video->width = $jo[$i]->width;
                 $video->height = $jo[$i]->height;
-				$video->framegrabUrl = 'http://vzaar.com/videos/' . $jo[$i]->id . '.frame';
+                $video->framegrabUrl = Vzaar::$url . 'videos/' . $jo[$i]->id . '.frame';
 
                 array_push($videos, $video);
             }


### PR DESCRIPTION
#### Summary
There's only 2 functional changes here. 

1. Removed a hardcoded reference to `http://vzaar.com`
2. Replaced a manually-constructed framegrab url with the one returned from the api call. This will now return a `view.vzaar` url in line with the api.

They will henceforth be referred to by their numbers.

The rest is changes to the README that I made as I tested. Mostly cleaning up of language, but also moved uploading & processing next to each other as many people don't realise that they need to do both, and contact support.

#### Intended effect
1. there should be no difference unless you edit the `Video::$url` constant when testing in an environment other than production. That this attribute is added to the response json is annoying, because it isn't part of the API, but it is now too late to remove as it is in the wild.

2. Rather than return a manually-constructed url as in `1.`, this now uses the `framegrabUrl` attribute that is already returned as part of the API call. 

#### How I tested
1. Made sure that the response still returned a correct url, and that it changed when altering the  `Video::$url` constant to a non-production url.
2. Made sure that the PHP code was correctly parsing the `framegrabUrl` attribute and including it in the json.
