### PR TITLE
added support for chunked uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ api_envs.php
 vendor
 .idea
 .DS_Store
+*.mp4

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,3 @@
-[1.2.3] 2016-05-31 EV<evi@vzaar.com>
-
-    * added support for chunked uploads
-
 [1.2.2] 2016-02-09 DRJ <dan@vzaar.com>
 
   * remove hardcoded url

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+[1.2.3] 2016-05-31 EV<evi@vzaar.com>
+
+    * added support for chunked uploads
+
 [1.2.2] 2016-02-09 DRJ <dan@vzaar.com>
 
   * remove hardcoded url

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * vzaar constants
+ */
+class Constants
+{
+	const Version  = '1.2.2';
+  const Uploader = 'php-1.2.2';
+}
+?>

--- a/src/UploadSignature.php
+++ b/src/UploadSignature.php
@@ -48,7 +48,7 @@ class UploadSignature {
      */
     function __construct($guid, $key, $https, $acl,
             $bucket, $policy, $expirationDate,
-            $accessKeyId, $signature, $uploadHostname) {
+            $accessKeyId, $signature, $uploadHostname, $chunkSize) {
         $this->guid = $guid;
         $this->key = $key;
         $this->https = $https;
@@ -59,6 +59,7 @@ class UploadSignature {
         $this->accesskeyid = $accessKeyId;
         $this->signature = $signature;
         $this->uploadHostname = $uploadHostname;
+        $this->chunkSize = $chunkSize;
     }
 
     static function fromJson($data) {

--- a/src/Vzaar.php
+++ b/src/Vzaar.php
@@ -4,6 +4,7 @@
  * Vzaar API Framework
  * @author Skitsanos
  */
+require_once 'Constants.php';
 require_once 'OAuth.php';
 require_once 'HttpRequest.php';
 require_once 'AccountType.php';
@@ -232,8 +233,16 @@ class Vzaar
             $file = "@" . $path;
         };
 
-        $s3Headers = array('AWSAccessKeyId' => $signature['vzaar-api']['accesskeyid'], 'Signature' => $signature['vzaar-api']['signature'], 'acl' => $signature['vzaar-api']['acl'], 'bucket' => $signature['vzaar-api']['bucket'], 'policy' => $signature['vzaar-api']['policy'], 'success_action_status' => 201, 'chunks' => 0,'chunk' =>0 , 'key' => $signature['vzaar-api']['key'], "file" => $file);
-
+        $s3Headers = array('AWSAccessKeyId' => $signature['vzaar-api']['accesskeyid'],
+          'Signature' => $signature['vzaar-api']['signature'],
+          'acl' => $signature['vzaar-api']['acl'],
+          'bucket' => $signature['vzaar-api']['bucket'],
+          'policy' => $signature['vzaar-api']['policy'],
+          'success_action_status' => 201,
+          'chunks' => 0,'chunk' => 0,
+          'x-amz-meta-uploader' => Constants::Uploader,
+          'key' => $signature['vzaar-api']['key'],
+          'file' => $file);
 
         $reply = $c->send($s3Headers, $path);
 
@@ -267,7 +276,17 @@ class Vzaar
 
             $data = fread($file, $chunkSize);
 
-            $s3Headers = array('AWSAccessKeyId' => $signature['vzaar-api']['accesskeyid'], 'Signature' => $signature['vzaar-api']['signature'], 'acl' => $signature['vzaar-api']['acl'], 'bucket' => $signature['vzaar-api']['bucket'], 'policy' => $signature['vzaar-api']['policy'], 'success_action_status' => 201, 'chunks' => $totalChunks ,'chunk' =>$chunk ,'key' => str_replace('${filename}',$filename,$signature['vzaar-api']['key']).'.'.$chunk , "file" => $data);
+            $s3Headers = array('AWSAccessKeyId' => $signature['vzaar-api']['accesskeyid'],
+              'Signature' => $signature['vzaar-api']['signature'],
+              'acl' => $signature['vzaar-api']['acl'],
+              'bucket' => $signature['vzaar-api']['bucket'],
+              'policy' => $signature['vzaar-api']['policy'],
+              'success_action_status' => 201,
+              'chunks' => $totalChunks,
+              'chunk' => $chunk,
+              'x-amz-meta-uploader' => Constants::Uploader,
+              'key' => str_replace('${filename}',$filename,$signature['vzaar-api']['key']).'.'.$chunk,
+              'file' => $data);
 
             $reply = $c->send($s3Headers, $path);
 
@@ -468,7 +487,7 @@ class Vzaar
                 $_query['filesize'] = $filesize;
             }
 
-        }else{
+        } else {
             $_url .= "?url=" .$path;
         }
 
@@ -482,6 +501,7 @@ class Vzaar
 
         if ($multipart) {
             $_query['multipart'] = 'true';
+            $_query['uploader'] = Constants::Uploader;
         }
 
         if(count($_query) > 0) {


### PR DESCRIPTION
#### Summary
To improve our ability to filter and troubleshoot API uploads more effectively, we now add metadata to S3 file uploads.

#### Intended effect
This change sends the `uploader` information to the signature endpoint which will return an S3 policy that expects an additional metadata header added to the S3 file upload: `x-amz-meta-uploader`

#### How I tested
This change was fully tested as part of [this APP pull request](https://github.com/vzaar/vzaar-app/pull/712).

#### Comments
The aforementioned APP pull request _must_ be merged and deployed to production _before_ this change is accepted.