### PR TITLE
(CB-603) metadata for s3 uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ api_envs.php
 vendor
 .idea
 .DS_Store
+*.mp4

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,11 @@
+[1.3.0] 2016-05-19 EV <evi@vzaar.com>
+
+  * add support for multipart uploads
+
 [1.2.2] 2016-02-09 DRJ <dan@vzaar.com>
 
-  * remove hardcoded url
-  * update README
+    * remove hardcoded url
+    * update README
 
 [1.2.1] 2016-02-09 EV <evi@vzaar.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,3 @@
-[1.2.3] 2016-05-31 EV<evi@vzaar.com>
-
-    * added support for chunked uploads
-
 [1.2.2] 2016-02-09 DRJ <dan@vzaar.com>
 
   * remove hardcoded url

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+[1.2.3] 2016-05-31 EV<evi@vzaar.com>
+
+    * added support for chunked uploads
+
 [1.2.2] 2016-02-09 DRJ <dan@vzaar.com>
 
   * remove hardcoded url

--- a/README.md
+++ b/README.md
@@ -1,14 +1,9 @@
-vzaar API PHP client
----
-vzaar API client for PHP developers.
-
----
+## vzaar API PHP client
+##### vzaar API client for PHP developers.
 
 >vzaar is the go to video hosting platform for business. Affordable, customizable and secure. Leverage the power of online video and enable commerce with vzaar. For more details and signup please visit [http://vzaar.com](http://vzaar.com)
 
-----
-
-####Using the library
+#### Using the library
 
 In order to start using vzaar API library
 
@@ -24,142 +19,147 @@ In order to use the vzaar API, you need to have a valid username and API token t
 To check you can connect via the API, you can run the following command:
 
 ```php
-echo(Vzaar::whoAmI());
+Vzaar::whoAmI();
 ```
 
-If it returns you your vzaar username, then you're good to go.
+If it returns your vzaar username, then you're good to go.
 
-####User Details
+#### User Details
 
 This API call returns the user's public details along with relevant metadata.
 
 ```php
-print_r(Vzaar::getUserDetails('VZAAR_USERNAME'));
+Vzaar::getUserDetails('VZAAR_USERNAME');
 ```
 
-Where _VZAAR__USERNAME_ is the vzaar username. Result of this call will be an object of UserDetails type.
-
-
-####Video List
+#### Video List
 
 This API call returns a list of the user's active videos along with relevant metadata. 20 videos are returned by default, but this is customizable.
 
 ```php
-print_r(Vzaar::getVideoList('VZAAR_USERNAME', true, 10));
+Vzaar::getVideoList('VZAAR_USERNAME', true, 10);
 ```
 
 In this example, the `true` parameter says that the API call should be authenticated. If you have your API settings set to 'private', then you will need to be authenticated.
 
-####Video Details
+#### Video Details
 
-This API call returns metadata about the selected video, like its dimensions, thumbnail information, author, duration, play count and so on.
-
-```php
-print_r(Vzaar::getVideoDetails(VZAAR_VIDEO_ID, true));
-```
-
-In this case, VZAAR_VIDEO_ID_ is the unique vzaar video ID assigned to a video after its processing.
-
-####Upload Signature
-
-In some cases you might need to not perform actual uploading from API but to use some third-party uploaders, like S3_Upload widget or similar, so you would need to get only upload signature for it.
+This API call returns metadata about the selected video (dimensions, thumbnail information, author, duration, play count, etc).
 
 ```php
-print_r(Vzaar::getUploadSignature());
+Vzaar::getVideoDetails(VZAAR_VIDEO_ID, true);
 ```
 
-###Uploading and processing videos
+In this case, _VZAAR_VIDEO_ID_ is the unique vzaar video ID assigned to a video after its processing.
+
+#### Special characters in filenames
+
+As per the AWS S3 documentation, only a small number of special characters in filenames are supported: http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
+
+The following special characters are supported by the vzaar API:
+
+- a-z
+- A-Z
+- 0-9
+- Space
+- - (dash)
+- . (dot)
+- ! (exclamation)
+- () (braces)
+
+#### Upload Signature
+
+If you are performing your own uploading (e.g. a 3rd-party or custom uploader) you will need to generate an S3 upload signature. You can then use this in your custom uploader.
+
+```php
+Vzaar::getUploadSignature(null, '/tmp/video.mp4', true, 'video.mp4', 102400);
+```
+
+##### Note
+As of version *1.3.0* the method signature for `getUploadSignature` has changed. The new method
+expects additional arguments which are required to support multipart uploads.
+
+### Uploading and processing videos
 
 Getting a video into your vzaar account is a two step process; you must first upload and then process the video.
 
-####Uploading videos from the filesystem
+#### Uploading videos from the filesystem
 
-Upload video from local drive directly to Amazon S3 bucket. Use this method when you build desktop apps or when you upload videos to vzaar directly from your server.
+Use this method when you build desktop apps or when you upload videos to vzaar directly from your server.
 
 ```php
-$filename = '548.mov'; // the file must be located in the same directory as the script. If not use full disk path.
-
-$file = getcwd() . '\\' . $filename;
-echo('file to upload: ' . $file);
-$result=Vzaar::uploadVideo($file);
-echo($result);
+$guid = Vzaar::uploadVideo("/path/to/file/video.mp4");
+Vzaar::processVideo($guid, "Title", "Description", "labels"));
 ```
 
-####Uploading videos using a url
+#### Uploading videos using a url
 
 Uploading a new video or replacing an existing one from a url
 
 ```php
 $url = "http://www.mywebsite.com/my_video.mp4";
-echo('uploading video from url: ' . $url);
-$video_id=Vzaar::uploadLink($url);
-echo($video_id);
+Vzaar::uploadLink($url, "Title");
 ```
 
-####Processing videos
+#### Processing videos
 
 This API call tells the vzaar system to process a newly uploaded video. This will encode it if necessary and then provide a vzaar video ID back.
 
+Typically you only need to do this when performing your own uploads (see _Upload Signature_).
+
 ```php
-$apireply = Vzaar::processVideo(GUID, VIDEO_TITLE, VIDEO_DESCRIPTION, VIDEO_LABELS, Profile::Original);
-echo($apireply)
+Vzaar::processVideo(GUID, TITLE, DESCRIPTION, LABELS, PROFILE);
 ```
 
-You would need to pass following parameters to this API function:
-
-* _GUID_ (string) - Specifies the guid to operate on. This will have been the return value from the previous `uploadVideo` or `uploadLink` operation.
-* _VIDEO__TITLE_ (string) - Specifies the title for the video
-* _VIDEO_DESCRIPTION_ (string) - Specifies the description for the video
-* _PROFILE_ (integer) - Specifies the size for the video to be encoded in. If not specified, this will use the vzaar default or the user default (if set)
-* _VIDEO_LABELS_ (string) - Comma separated list of labels to be assigned to the video
+* `GUID` (string) - Specifies the guid to operate on. Get this from the result of your `getUploadSignature` API call.
+* `TITLE` (string) - Specifies the title for the video.
+* `DESCRIPTION` (string) - Specifies the description for the video.
+* `LABELS` (string) - Comma separated list of labels to be assigned to the video.
+* `PROFILE` (integer) - Specifies the size for the video to be encoded in. If not specified, this will use the vzaar default or the user default (if set). See `src/Vzaar.php` for options.
 
 
-####Uploading thumbnails
+#### Uploading thumbnails
 
 Upload thumbnails for a video by using the video id.
 
 ```php
 $video_id = 123;
-
-$thumb_path = "/home/herk/my_image.jpg";
-echo('uploading thumbnail for video:' . $video_id . ', file path:' . $thumb_path);
-$result=Vzaar::uploadThumbnail($video_id, $thumb_path);
-echo($result);
+$thumb_path = "/path/to/file/image.jpg";
+Vzaar::uploadThumbnail($video_id, $thumb_path);
 ```
 
-####Uploading thumbnails
+#### Uploading thumbnails
 
 Generate a thumbnail based on frame time.
 
 ```php
 $video_id = 123;
-
-$result=Vzaar::generateThumbnail($video_id, 3);
-echo($result);
+Vzaar::generateThumbnail($video_id, 3);
 ```
 
 
-####Editing video
+#### Editing video
 
-This API call allows a user to edit or change details about a video in the system.
+This API call allows a user to edit or change details about a video.
 
 ```php
-$apiresult = Vzaar::editVideo(VIDEO_ID, VIDEO_TITLE, VIDEO_DESCRIPTION, MARK_AS_PRIVATE);
+Vzaar::editVideo(VIDEO_ID, VIDEO_TITLE, VIDEO_DESCRIPTION, MARK_AS_PRIVATE);
 ```
 
 The following arguments should be passed to the method:
 
-* _VIDEO_ID_ (integer) - Unique vzaar Video ID of the video you are going to modify
-* _VIDEO_TITLE_ (string) - Specifies the new title for the video
-* _VIDEO_DESCRIPTION_ (string) - Specifies the new description for the video
-* _MARK_AS_PRIVATE_ (boolean) (true|false) - Marks the video as private or public
+* `VIDEO_ID` (integer) - Unique vzaar Video ID of the video you are going to modify
+* `VIDEO_TITLE` (string) - Specifies the new title for the video
+* `VIDEO_DESCRIPTION` (string) - Specifies the new description for the video
+* `MARK_AS_PRIVATE` (boolean) (true|false) - Marks the video as private or public
 
 
-####Deleting video
-This API call allows you to delete a video from your account. If deletion was successful it will return you _true_ otherwise _false_.
+#### Deleting video
+
+This API call allows you to delete a video from your account. If deletion was successful it will return _true_ otherwise _false_.
 
 ```php
-$apiresult = Vzaar::deleteVideo(VZAAR_VIDEO_ID);
+Vzaar::deleteVideo(VZAAR_VIDEO_ID);
 ```
 
 

--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,28 @@
-{ "name": "vzaar/vzaar-api-php",
+{
+  "name": "vzaar/vzaar-api-php",
   "description": "The PHP client for Vzaar API.",
   "type": "library",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "keywords": [ "vzaar", "video", "api" ],
-
   "homepage": "https://github.com/vzaar/vzaar-api-php",
   "license": "MIT",
   "authors": [
-    { "name": "Evi Skitsanos",
-      "email": "evi@vzaar.com",
-      "role": "lead" },
-
-    { "name": "Jozef Chraplewski",
-      "email": "jozef@vzaar.com" }
+    {
+      "name": "Evi Skitsanos",
+      "email": "evi@vzaar.com"
+    },
+    {
+      "name": "Jozef Chraplewski",
+      "email": "jozef@vzaar.com"
+    },
+    {
+      "name": "Ed James",
+      "email": "ed@vzaar.com"
+    }
   ],
-
   "support": {
     "issues": "https://vzaar.com/help"
   },
-
   "require-dev": {
     "phpunit/phpunit": "~4.3.5"
   }

--- a/examples/UploadVideoTest.php
+++ b/examples/UploadVideoTest.php
@@ -24,7 +24,7 @@ class UploadVideoTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testNonMulitpartVideoSignature() {
-        $signature = Vzaar::getUploadSignature();
+        $signature = Vzaar::getUploadSignature(null, '/tmp/video.mp4', false, 'video.mp4', 102400);
         $policy = base64_decode($signature['vzaar-api']['policy']);
 
         // doesn't have chunk and chunks policy
@@ -33,7 +33,7 @@ class UploadVideoTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testMulitpartVideoSignature() {
-        $signature = Vzaar::getUploadSignature(null, true);
+        $signature = Vzaar::getUploadSignature(null, '/tmp/video.mp4', true, 'video.mp4', 102400);
         $policy = base64_decode($signature['vzaar-api']['policy']);
 
         // has chunk and chunks policy

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * vzaar constants
+ */
+class Constants
+{
+	const Version  = '1.2.2';
+  const Uploader = 'php-1.2.2';
+}
+?>

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -4,7 +4,7 @@
  */
 class Constants
 {
-	const Version  = '1.2.2';
-  const Uploader = 'php-1.2.2';
+	const Version  = '1.3.0';
+  const Uploader = 'php-1.3.0';
 }
 ?>

--- a/src/UploadSignature.php
+++ b/src/UploadSignature.php
@@ -48,7 +48,7 @@ class UploadSignature {
      */
     function __construct($guid, $key, $https, $acl,
             $bucket, $policy, $expirationDate,
-            $accessKeyId, $signature, $uploadHostname) {
+            $accessKeyId, $signature, $uploadHostname, $chunkSize) {
         $this->guid = $guid;
         $this->key = $key;
         $this->https = $https;
@@ -59,6 +59,7 @@ class UploadSignature {
         $this->accesskeyid = $accessKeyId;
         $this->signature = $signature;
         $this->uploadHostname = $uploadHostname;
+        $this->chunkSize = $chunkSize;
     }
 
     static function fromJson($data) {

--- a/src/Vzaar.php
+++ b/src/Vzaar.php
@@ -4,6 +4,7 @@
  * Vzaar API Framework
  * @author Skitsanos
  */
+require_once 'Constants.php';
 require_once 'OAuth.php';
 require_once 'HttpRequest.php';
 require_once 'AccountType.php';
@@ -232,8 +233,16 @@ class Vzaar
             $file = "@" . $path;
         };
 
-        $s3Headers = array('AWSAccessKeyId' => $signature['vzaar-api']['accesskeyid'], 'Signature' => $signature['vzaar-api']['signature'], 'acl' => $signature['vzaar-api']['acl'], 'bucket' => $signature['vzaar-api']['bucket'], 'policy' => $signature['vzaar-api']['policy'], 'success_action_status' => 201, 'chunks' => 0,'chunk' =>0 , 'key' => $signature['vzaar-api']['key'], "file" => $file);
-
+        $s3Headers = array('AWSAccessKeyId' => $signature['vzaar-api']['accesskeyid'],
+          'Signature' => $signature['vzaar-api']['signature'],
+          'acl' => $signature['vzaar-api']['acl'],
+          'bucket' => $signature['vzaar-api']['bucket'],
+          'policy' => $signature['vzaar-api']['policy'],
+          'success_action_status' => 201,
+          'chunks' => 0,'chunk' => 0,
+          'x-amz-meta-uploader' => Constants::Uploader,
+          'key' => $signature['vzaar-api']['key'],
+          'file' => $file);
 
         $reply = $c->send($s3Headers, $path);
 
@@ -267,7 +276,17 @@ class Vzaar
 
             $data = fread($file, $chunkSize);
 
-            $s3Headers = array('AWSAccessKeyId' => $signature['vzaar-api']['accesskeyid'], 'Signature' => $signature['vzaar-api']['signature'], 'acl' => $signature['vzaar-api']['acl'], 'bucket' => $signature['vzaar-api']['bucket'], 'policy' => $signature['vzaar-api']['policy'], 'success_action_status' => 201, 'chunks' => $totalChunks ,'chunk' =>$chunk ,'key' => str_replace('${filename}',$filename,$signature['vzaar-api']['key']).'.'.$chunk , "file" => $data);
+            $s3Headers = array('AWSAccessKeyId' => $signature['vzaar-api']['accesskeyid'],
+              'Signature' => $signature['vzaar-api']['signature'],
+              'acl' => $signature['vzaar-api']['acl'],
+              'bucket' => $signature['vzaar-api']['bucket'],
+              'policy' => $signature['vzaar-api']['policy'],
+              'success_action_status' => 201,
+              'chunks' => $totalChunks,
+              'chunk' => $chunk,
+              'x-amz-meta-uploader' => Constants::Uploader,
+              'key' => str_replace('${filename}',$filename,$signature['vzaar-api']['key']).'.'.$chunk,
+              'file' => $data);
 
             $reply = $c->send($s3Headers, $path);
 
@@ -468,7 +487,7 @@ class Vzaar
                 $_query['filesize'] = $filesize;
             }
 
-        }else{
+        } else {
             $_url .= "?url=" .$path;
         }
 
@@ -482,6 +501,7 @@ class Vzaar
 
         if ($multipart) {
             $_query['multipart'] = 'true';
+            $_query['uploader'] = Constants::Uploader;
         }
 
         if(count($_query) > 0) {

--- a/src/Vzaar.php
+++ b/src/Vzaar.php
@@ -473,50 +473,49 @@ class Vzaar
         if($path==null){
             throw new VzaarException('path/url could not be null');
         }
-        $_url = self::$url . "api/v1.1/videos/signature";
-        $_query = Array();
 
         if (!preg_match('/^(https?:\/\/+[\w\-]+\.[\w\-]+)/i',$path))
         {
-            $_url .= "?path=" .$path;
+            $_url = "path=" .$path;
             if ($filename != null) {
-                $_query['filename'] = $filename;
+              $_url .= "&filename=" .$filename;
             }
 
             if ($filesize != null) {
-                $_query['filesize'] = $filesize;
+              $_url .= "&filesize=" .$filesize;
             }
 
         } else {
-            $_url .= "?url=" .$path;
+            $_url .= "url=" .$path;
         }
 
         if (Vzaar::$enableFlashSupport) {
-            $_query['flash_request'] = 'true';
+          $_url .= "&flash_request=true";
         }
 
         if ($redirectUrl != null) {
-            $_query['success_action_redirect'] = $redirectUrl;
+          $_url .= "&success_action_redirect=" .$redirectUrl;
         }
 
         if ($multipart) {
-            $_query['multipart'] = 'true';
-            $_query['uploader'] = Constants::Uploader;
+          $_url .= "&multipart=true";
+          $_url .= "&uploader=" .Constants::Uploader;
         }
 
-        if(count($_query) > 0) {
-            $_url .= "&" . http_build_query($_query);
-        }
+        $_base_url = self::$url . "api/v1.1/videos/signature?";
+        $_auth_url = $_base_url . $_url;
+        $_http_url = $_base_url . str_replace(' ', '+', $_url);
 
-        $req = Vzaar::setAuth($_url, 'GET');
+        $req = Vzaar::setAuth($_auth_url, 'GET');
         $req->verbose = Vzaar::$enableHttpVerbose;
 
-        $c = new HttpRequest($_url);
+        $c = new HttpRequest($_http_url);
         $c->method = 'GET';
         array_push($c->headers, $req->to_header());
         array_push($c->headers, 'User-Agent: Vzaar OAuth Client');
 
-        return UploadSignature::fromXml($c->send());
+        $data = $c->send();
+        return UploadSignature::fromXml($data);
     }
 
     /**


### PR DESCRIPTION
#### Summary
This changes follow on from [this pull request](https://github.com/vzaar/vzaar-api-php/pull/12) which added full support for multipart uploads. That pull request was merged and then rolled back on `master`.

That pull request introduced a regression which meant filenames that contained a space character would now fail, where in previous versions (1.2.2) they did not.

#### Intended effect
This change correctly handles filenames which contain space characters.

#### How I tested
I created 3 files for testing with the following names:

- `vid-this-(is)_a VAL1D.filename!.mp4`
- `vid HD.mp4`
- `vid-medium.mp4`

Then, using my API token and secret, I used the following code to upload and encode the videos. All 3 videos encoded as expected.

```
$guid = Vzaar::uploadVideo("/Users/edjames/Development/vzaar/vzaar-api-php/vid-this-(is)_a VAL1D.filename!.mp4");
echo 'guid: '; echo $guid; echo "\n";
echo 'vid : '; print_r(Vzaar::processVideo($guid, "(php 1.3.0) multipart 1", "", "")); echo "\n";

$guid = Vzaar::uploadVideo("/Users/edjames/Development/vzaar/vzaar-api-php/vid HD.mp4");
echo 'guid: '; echo $guid; echo "\n";
echo 'vid : '; print_r(Vzaar::processVideo($guid, "(php 1.3.0) multipart 1", "", "")); echo "\n";

$guid = Vzaar::uploadVideo("/Users/edjames/Development/vzaar/vzaar-api-php/vid-medium.mp4");
echo 'guid: '; echo $guid; echo "\n";
echo 'vid : '; print_r(Vzaar::processVideo($guid, "(php 1.3.0) no multipart", "", "")); echo "\n";
```

This produced the following output:

```
guid: vze89cbc2d841f4c0bb33287f68acd317c
vid : 7125444
guid: vz8a4199b9c19a4ce0a7ccc1943724fc6a
vid : 7125446
guid: vz1eaa1707886445378d5639d259246702
vid : 7125447
```