### PR TITLE
Fix composer autoloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ Vzaar::$token = 'VZAAR_API_TOKEN';
 Vzaar::$secret = 'VZAAR_USERNAME';
 ```
 
+For version > 1.3.0, if you have installed the library through Composer, you may require the Composer autoload file instead of individual Vzaar source files. Composer will automatically find and load your classes when used:
+
+```php
+require_once 'vendor/autoload.php';
+
+Vzaar::$token = 'VZAAR_API_TOKEN';
+Vzaar::$secret = 'VZAAR_USERNAME';
+```
+
 In order to use the vzaar API, you need to have a valid username and API token that you can get from your vzaar dashboard at [http://app.vzaar.com/settings/api](http://app.vzaar.com/settings/api)
 
 To check you can connect via the API, you can run the following command:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Vzaar::$token = 'VZAAR_API_TOKEN';
 Vzaar::$secret = 'VZAAR_USERNAME';
 ```
 
-For version > 1.3.0, if you have installed the library through Composer, you may require the Composer autoload file instead of individual Vzaar source files. Composer will automatically find and load your classes when used:
+*For versions > 1.3.0*, if you have installed the library through Composer, you may require the Composer autoload file instead of individual Vzaar source files. Composer will automatically find and load your classes when used:
 
 ```php
 require_once 'vendor/autoload.php';

--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,8 @@
   },
   "require-dev": {
     "phpunit/phpunit": "~4.3.5"
+  },
+  "autoload": {
+    "classmap": ["src"]
   }
 }


### PR DESCRIPTION
This pull request updates the composer.json file so that including the `vendor/autoload.php` file will automatically lazy load any .php or .inc file in Vzaar's `src/` directory when requested.

As a result, projects using composer's autoloader will not need to manually include individual Vzaar SDK files. This will not break any code that does continue to manually include individual Vzaar SDK files.

The README.md file has also been updated to explain the distinction, noting this change would be in versions greater than the current version of 1.3.0, as the current version does not include this functionality.

For reference, info about Composer's classmap function can be found here: https://getcomposer.org/doc/04-schema.md#classmap