### PR TITLE
Small readme copy clarification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Vzaar::uploadLink($url, "Title");
 
 #### Processing videos
 
-This API call tells the vzaar system to process a newly uploaded video. This will encode it if necessary and then provide a vzaar video ID back.
+This API call tells the vzaar system to process a newly uploaded video. This will provide a vzaar video ID, then encode the video if necessary. 
 
 Typically you only need to do this when performing your own uploads (see _Upload Signature_).
 


### PR DESCRIPTION
This (as pointed out by a user) implied that the ID is only returned after the video is encoded, which is incorrect. Just edited to clear that up. 

If there's a better way for me to propose changes in these docs, please let me know.