### PR TITLE
(DEV-575) adds category create, update, delete endpoints

### DIFF
--- a/examples/Category.php
+++ b/examples/Category.php
@@ -150,6 +150,65 @@
 
     }
 
+
+    //
+    // Create / Update / Delete
+    //
+    try {
+
+      // create
+
+      $params = array('name' => 'category from php sdk examples');
+
+      $cat = VzaarApi\Category::create($params);
+      echo PHP_EOL.'Created Category: ' .$cat->id .' '. $cat->name;
+
+      $params['parent_id'] = $cat->id;
+      $subcat = VzaarApi\Category::create($params);
+      echo PHP_EOL.'Created Category: ' .$subcat->id .' '. $subcat->name;
+
+      $params['parent_id'] = $subcat->id;
+      $subsubcat = VzaarApi\Category::create($params);
+      echo PHP_EOL.'Created Category: ' .$subsubcat->id .' '. $subsubcat->name;
+
+      echo PHP_EOL;
+
+      // update
+
+      echo PHP_EOL.'Updating Category: ' .$subcat->id .' ('. $subcat->name .') moving from depth ' .$subcat->depth .' to root';
+      $subcat->name = 'updated name from php sdk';
+      $subcat->move_to_root = true;
+      $subcat->save();
+
+      echo PHP_EOL.'Updated Category: ' .$subcat->id .' ('. $subcat->name .') depth is now ' .$subcat->depth;
+
+      echo PHP_EOL;
+
+      echo PHP_EOL.'Moving it back again...';
+      $subcat->name = 'updated name again from php sdk';
+      $subcat->parent_id = $cat->id;
+      $subcat->save();
+      echo PHP_EOL.'Updated Category: ' .$subcat->id .' ('. $subcat->name .') depth is now ' .$subcat->depth;
+
+      echo PHP_EOL;
+
+      echo PHP_EOL.'Deleting category: ' .$cat->id .' and its subcategories';
+      $cat->delete();
+
+      echo PHP_EOL;
+
+    } catch(VzaarApi\Exceptions\VzaarException $ve) {
+
+      echo $ve->getMessage();
+
+    } catch(VzaarApi\Exceptions\VzaarError $verr) {
+
+      echo $verr->getMessage();
+
+    }
+
+
+
     echo PHP_EOL;
 
 ?>

--- a/lib/vzaar/Category.php
+++ b/lib/vzaar/Category.php
@@ -41,4 +41,31 @@ class Category extends Record
     }//end find()
 
 
+    public static function create($params, $client = null)
+    {
+
+        $category = new self($client);
+        $category->crudCreate($params);
+
+        return $category;
+
+    }//end create()
+
+
+    public function save($params = null)
+    {
+
+        $this->crudUpdate($params);
+
+    }//end save()
+
+
+    public function delete()
+    {
+
+        $this->crudDelete();
+
+    }//end delete()
+
+
 }//end class


### PR DESCRIPTION
#### Summary
This PR adds the category create, update and delete endpoints

#### Intended effect
A user should be able to create either top level categories, or subcategories by specifying a `parent_id`. They should be able to update a category's name, or move it by using either the `parent_id` or `move_to_root` functions. They should be able to delete categories.

#### How I tested
Mainly in the console. You can use this as  a testing script: https://github.com/vzaar/vzaar-api-php/blob/7d5bf04649ce79c66a7201e08e3a1a37d2ab295f/examples/Category.php#L155

#### Comments / Potential problems / Questions / Side effects
I'm not keen on the lack of category update tests, but phpunit is pretty alien to me right now. 